### PR TITLE
add python version requirement for aspose

### DIFF
--- a/cases/Aspose/case.yml
+++ b/cases/Aspose/case.yml
@@ -17,6 +17,7 @@
     # - Linux
     # - macOS
   # Does commercial compilation change things.
+  python_version_req: "python_version < 0x30"
   commercial: "no"
   # Does this package create a GUI program.
   gui: "no"


### PR DESCRIPTION
this aspose does not support python 3.12 yet, adjust yaml to account for that